### PR TITLE
Pridany Trakt manager rating

### DIFF
--- a/resources/language/Czech/strings.xml
+++ b/resources/language/Czech/strings.xml
@@ -164,6 +164,21 @@
     <string id="30981">Importovat do seznamu</string>
     <string id="30982">ďalšia strana</string>
 
+    <string id="30987">Hodnotenie odoslané (%d)</string>
+    <string id="30988">Hodnotenie odstránené</string>
+    <string id="30989">Ohodnotiť</string>
+    <string id="30990">Odstrániť hodnotenie</string>
+    <string id="30991"> 1 - Najhoršie</string>
+    <string id="30992"> 2 - Veľmi zlé</string>
+    <string id="30993"> 3 - Zlé</string>
+    <string id="30994"> 4 - Podpriemerné</string>
+    <string id="30995"> 5 - Priemerné</string>
+    <string id="30996"> 6 - Prijateľné</string>
+    <string id="30997"> 7 - Dobré</string>
+    <string id="30998"> 8 - Veľmi dobré</string>
+    <string id="30999"> 9 - Výborné</string>
+    <string id="31000">10 - Najlepšie</string>
+
     <!-- dni v tyzdni -->
     <string id="30911">Pondělí</string>
     <string id="30912">Úterý</string>    

--- a/resources/language/Czech/strings.xml
+++ b/resources/language/Czech/strings.xml
@@ -83,13 +83,13 @@
     <string id="30800">Používať zbierky</string>
     <string id="30801">Používať zoznam na pozretie</string>
     <string id="30802">Zobraziť priateľov a sledovaných</string>
-    <string id="30803">Priatelia a sledovaní pod tvojími zoznamami</string>
+    <string id="30803">Priatelia a sledovaní pod mojimi zoznamami</string>
     <string id="30804">Zobraziť obľúbené zoznamy</string>
-    <string id="30805">Obľúbené zoznamy pod tvojími zoznamami</string>
+    <string id="30805">Obľúbené zoznamy pod mojimi zoznamami</string>
     <string id="30806">Zobraziť populárne zoznamy</string>
-    <string id="30807">Populárne zoznamy pod tvojími zoznamami</string>
+    <string id="30807">Populárne zoznamy pod mojimi zoznamami</string>
     <string id="30808">Zobraziť populárne zoznamy za týždeň</string>
-    <string id="30809">Populárne zoznamy za týždeň pod tvojími zoznamami</string>
+    <string id="30809">Populárne zoznamy za týždeň pod mojimi zoznamami</string>
 
     <!-- texty v menu -->
     <string id="30901">Filmy</string>

--- a/resources/language/Czech/strings.xml
+++ b/resources/language/Czech/strings.xml
@@ -79,6 +79,18 @@
     <string id="30700">Povolit historii</string>
     <string id="30701">Počet položek v historií</string>
 
+    <string id="30080">Trakt.tv</string>
+    <string id="30800">Používať zbierky</string>
+    <string id="30801">Používať zoznam na pozretie</string>
+    <string id="30802">Zobraziť priateľov a sledovaných</string>
+    <string id="30803">Priatelia a sledovaní pod tvojími zoznamami</string>
+    <string id="30804">Zobraziť obľúbené zoznamy</string>
+    <string id="30805">Obľúbené zoznamy pod tvojími zoznamami</string>
+    <string id="30806">Zobraziť populárne zoznamy</string>
+    <string id="30807">Populárne zoznamy pod tvojími zoznamami</string>
+    <string id="30808">Zobraziť populárne zoznamy za týždeň</string>
+    <string id="30809">Populárne zoznamy za týždeň pod tvojími zoznamami</string>
+
     <!-- texty v menu -->
     <string id="30901">Filmy</string>
     <string id="30902">Seriály</string>

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -91,20 +91,6 @@
     <string id="30808">Display Trending Lists</string>
     <string id="30809">Trending Lists below your lists</string>
     
-    <string id="30810"></string>
-    <string id="30811"></string>
-    <string id="30812"></string>
-    <string id="30813"></string>
-    <string id="30814"></string>
-    <string id="30815"></string>
-    <string id="30816"></string>
-    <string id="30817"></string>
-    <string id="30818"></string>
-    <string id="30819"></string>
-    <string id="30820"></string>
-
-
-
     <!-- texty v menu -->
     <string id="30901">Movies</string>
     <string id="30902">Series</string>

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -79,6 +79,32 @@
     <string id="30700">Enable history</string>
     <string id="30701">Items in history</string>
 
+    <string id="30080">Trakt.tv</string>
+    <string id="30800">Use collection</string>
+    <string id="30801">Use watchlist</string>
+    <string id="30802">Display Friends &amp; Following</string>
+    <string id="30803">Friends &amp; Following below your lists</string>
+    <string id="30804">Display Liked Lists</string>
+    <string id="30805">Liked Lists below your lists</string>
+    <string id="30806">Display Popular Lists</string>
+    <string id="30807">Popular Lists below your lists</string>
+    <string id="30808">Display Trending Lists</string>
+    <string id="30809">Trending Lists below your lists</string>
+    
+    <string id="30810"></string>
+    <string id="30811"></string>
+    <string id="30812"></string>
+    <string id="30813"></string>
+    <string id="30814"></string>
+    <string id="30815"></string>
+    <string id="30816"></string>
+    <string id="30817"></string>
+    <string id="30818"></string>
+    <string id="30819"></string>
+    <string id="30820"></string>
+
+
+
     <!-- texty v menu -->
     <string id="30901">Movies</string>
     <string id="30902">Series</string>

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -163,7 +163,22 @@
     <string id="30980">Clone list</string>
     <string id="30981">Import to list</string>
     <string id="30982">next</string>
-    
+
+    <string id="30987">Rating added (%d)</string>
+    <string id="30988">Rating removed</string>
+    <string id="30989">Rate this</string>
+    <string id="30990">Remove rating</string>
+    <string id="30991"> 1 - Weak sauce :(</string>
+    <string id="30992"> 2 - Terrible</string>
+    <string id="30993"> 3 - Bad</string>
+    <string id="30994"> 4 - Poor</string>
+    <string id="30995"> 5 - Meh</string>
+    <string id="30996"> 6 - Unrate</string>
+    <string id="30997"> 7 - Good</string>
+    <string id="30998"> 8 - Great</string>
+    <string id="30999"> 9 - Superb</string>
+    <string id="31000">10 - Totally ninja!</string>
+
     <!-- dni v tyzdni -->
     <string id="30911">Monday</string>
     <string id="30912">Tuesday</string>    

--- a/resources/language/Slovak/strings.xml
+++ b/resources/language/Slovak/strings.xml
@@ -83,13 +83,13 @@
     <string id="30800">Používať zbierky</string>
     <string id="30801">Používať zoznam na pozretie</string>
     <string id="30802">Zobraziť priateľov a sledovaných</string>
-    <string id="30803">Priatelia a sledovaní pod tvojími zoznamami</string>
+    <string id="30803">Priatelia a sledovaní pod mojimi zoznamami</string>
     <string id="30804">Zobraziť obľúbené zoznamy</string>
-    <string id="30805">Obľúbené zoznamy pod tvojími zoznamami</string>
+    <string id="30805">Obľúbené zoznamy pod mojimi zoznamami</string>
     <string id="30806">Zobraziť populárne zoznamy</string>
-    <string id="30807">Populárne zoznamy pod tvojími zoznamami</string>
+    <string id="30807">Populárne zoznamy pod mojimi zoznamami</string>
     <string id="30808">Zobraziť populárne zoznamy za týždeň</string>
-    <string id="30809">Populárne zoznamy za týždeň pod tvojími zoznamami</string>
+    <string id="30809">Populárne zoznamy za týždeň pod mojimi zoznamami</string>
 
     <!-- texty v menu -->
     <string id="30901">Filmy</string>

--- a/resources/language/Slovak/strings.xml
+++ b/resources/language/Slovak/strings.xml
@@ -79,6 +79,18 @@
     <string id="30700">Povoliť históriu</string>
     <string id="30701">Počet položiek v historií</string>
 
+    <string id="30080">Trakt.tv</string>
+    <string id="30800">Používať zbierky</string>
+    <string id="30801">Používať zoznam na pozretie</string>
+    <string id="30802">Zobraziť priateľov a sledovaných</string>
+    <string id="30803">Priatelia a sledovaní pod tvojími zoznamami</string>
+    <string id="30804">Zobraziť obľúbené zoznamy</string>
+    <string id="30805">Obľúbené zoznamy pod tvojími zoznamami</string>
+    <string id="30806">Zobraziť populárne zoznamy</string>
+    <string id="30807">Populárne zoznamy pod tvojími zoznamami</string>
+    <string id="30808">Zobraziť populárne zoznamy za týždeň</string>
+    <string id="30809">Populárne zoznamy za týždeň pod tvojími zoznamami</string>
+
     <!-- texty v menu -->
     <string id="30901">Filmy</string>
     <string id="30902">Seriály</string>
@@ -164,19 +176,20 @@
     <string id="30981">Importovať do zoznamu</string>
     <string id="30982">ďalšia strana</string>
     
+
     <string id="30987">Hodnotenie odoslané (%d)</string>
     <string id="30988">Hodnotenie odstránené</string>
     <string id="30989">Ohodnotiť</string>
     <string id="30990">Odstrániť hodnotenie</string>
-    <string id="30991"> 1 - Najhoršie</string>
-    <string id="30992"> 2 - Veľmi zlé</string>
-    <string id="30993"> 3 - Zlé</string>
-    <string id="30994"> 4 - Podpriemerné</string>
-    <string id="30995"> 5 - Priemerné</string>
-    <string id="30996"> 6 - Prijateľné</string>
-    <string id="30997"> 7 - Dobré</string>
-    <string id="30998"> 8 - Veľmi dobré</string>
-    <string id="30999"> 9 - Výborné</string>
+    <string id="30991">  1 - Najhoršie</string>
+    <string id="30992">  2 - Veľmi zlé</string>
+    <string id="30993">  3 - Zlé</string>
+    <string id="30994">  4 - Podpriemerné</string>
+    <string id="30995">  5 - Priemerné</string>
+    <string id="30996">  6 - Prijateľné</string>
+    <string id="30997">  7 - Dobré</string>
+    <string id="30998">  8 - Veľmi dobré</string>
+    <string id="30999">  9 - Výborné</string>
     <string id="31000">10 - Najlepšie</string>
 
     <!-- dni v tyzdni -->

--- a/resources/language/Slovak/strings.xml
+++ b/resources/language/Slovak/strings.xml
@@ -164,6 +164,21 @@
     <string id="30981">Importovať do zoznamu</string>
     <string id="30982">ďalšia strana</string>
     
+    <string id="30987">Hodnotenie odoslané (%d)</string>
+    <string id="30988">Hodnotenie odstránené</string>
+    <string id="30989">Ohodnotiť</string>
+    <string id="30990">Odstrániť hodnotenie</string>
+    <string id="30991"> 1 - Najhoršie</string>
+    <string id="30992"> 2 - Veľmi zlé</string>
+    <string id="30993"> 3 - Zlé</string>
+    <string id="30994"> 4 - Podpriemerné</string>
+    <string id="30995"> 5 - Priemerné</string>
+    <string id="30996"> 6 - Prijateľné</string>
+    <string id="30997"> 7 - Dobré</string>
+    <string id="30998"> 8 - Veľmi dobré</string>
+    <string id="30999"> 9 - Výborné</string>
+    <string id="31000">10 - Najlepšie</string>
+
     <!-- dni v tyzdni -->
     <string id="30911">Pondelok</string>
     <string id="30912">Utorok</string>    

--- a/resources/lib/scinema.py
+++ b/resources/lib/scinema.py
@@ -471,14 +471,11 @@ class StreamCinemaContentProvider(ContentProvider):
             #name, imdb, tvdb, content
             content = 'series' if 'season' in data and data['season'].isdigit(
             ) else 'movie'
-            imdb = 'tt%07d' % int(data['imdb']) if 'imdb' in data else 0
-            tvdb = data['tvdb'] if 'tvdb' in data else 0
             menu.update({
                 "Trakt menu": {
                     "action": "traktManager",
                     'name': data['title'],
-                    'imdb': imdb,
-                    'tvdb': tvdb,
+                    'trakt': data['trakt'],
                     'content': content
                 }
             })

--- a/resources/lib/scutils.py
+++ b/resources/lib/scutils.py
@@ -719,7 +719,8 @@ class KODISCLib(xbmcprovider.XBMCMultiResolverContentProvider):
                 return self.endOfDirectory()
 
             if action[0:5] == 'trakt':
-                if trakt.getTraktCredentialsInfo() == False: return
+                if trakt.getTraktCredentialsInfo() == False:
+                    return
 
                 if action == "traktManager":
                     trakt.manager(params['name'], params['trakt'],

--- a/resources/lib/scutils.py
+++ b/resources/lib/scutils.py
@@ -722,8 +722,8 @@ class KODISCLib(xbmcprovider.XBMCMultiResolverContentProvider):
                 if trakt.getTraktCredentialsInfo() == False: return
 
                 if action == "traktManager":
-                    trakt.manager(params['name'], params['imdb'],
-                                  params['tvdb'], params['content'])
+                    trakt.manager(params['name'], params['trakt'],
+                                  params['content'])
                     return
 
                 if action == 'traktWatchlist':

--- a/resources/lib/trakt.py
+++ b/resources/lib/trakt.py
@@ -241,52 +241,55 @@ def getLists(user='me'):
     items = []
     items_below = []
     if sctop.getSettingAsBool('trakt.watchlist') or user != 'me':
-        items += [
-            {
-                'type': 'dir',
-                'title': '[B]$30944[/B]',
-                'action': 'traktShowList',
-                'id': 'watchlist',
-                'tl': 'watchlist',
-                'tu': user
-            }]
+        items += [{
+            'type': 'dir',
+            'title': '[B]$30944[/B]',
+            'action': 'traktShowList',
+            'id': 'watchlist',
+            'tl': 'watchlist',
+            'tu': user
+        }]
 
     items += [{
-                'type': 'dir',
-                'title': '[B]$30958[/B]',
-                'action': 'traktHistory',
-                'id': 'history',
-                'tu': user
-        }]
-        #,
-        #{
-        #    'type': 'dir',
-        #    'title': 'Nedokoncene',
-        #    'url': 'cmd://Container.Update("%s")' % \
-        #        (xbmcutil._create_plugin_url({'action':'traktShowList', 'id':'progress'}))
-        #}
+        'type': 'dir',
+        'title': '[B]$30958[/B]',
+        'action': 'traktHistory',
+        'id': 'history',
+        'tu': user
+    }]
+    #,
+    #{
+    #    'type': 'dir',
+    #    'title': 'Nedokoncene',
+    #    'url': 'cmd://Container.Update("%s")' % \
+    #        (xbmcutil._create_plugin_url({'action':'traktShowList', 'id':'progress'}))
+    #}
 
     if user == "me":
         if sctop.getSettingAsBool('trakt.following'):
             below = sctop.getSettingAsBool('trakt.following-below')
             (items_below if below else items).append({
-                'action': 'traktFollowing',
-                'title': '[B]$30963[/B]',
-                'id': 'following',
-                'type': 'dir'
+                'action':
+                'traktFollowing',
+                'title':
+                '[B]$30963[/B]',
+                'id':
+                'following',
+                'type':
+                'dir'
             })
 
-        for l, t in (('liked', '$30964'),
-                     ('popular', '$30965'),
-                     ('trending', '$30966')):
+        for l, t in (('liked', '$30964'), ('popular', '$30965'), ('trending',
+                                                                  '$30966')):
             if sctop.getSettingAsBool('trakt.%s' % l):
-                (items_below if sctop.getSettingAsBool('trakt.%s-below' % l) else items).append({
-                    'action': 'traktSpecialLists',
-                    'title': '[B]%s[/B]' % t,
-                    'id': '%s_lists' % l,
-                    'type': 'dir',
-                    'page': '1'
-                })
+                (items_below if sctop.getSettingAsBool('trakt.%s-below' % l)
+                 else items).append({
+                     'action': 'traktSpecialLists',
+                     'title': '[B]%s[/B]' % t,
+                     'id': '%s_lists' % l,
+                     'type': 'dir',
+                     'page': '1'
+                 })
 
     lists = [{
         'action': 'traktShowList',
@@ -457,27 +460,22 @@ def manager(name, trakt, content):
         icon = sctop.infoLabel('ListItem.Icon')
         message = sctop.getString(30941).encode('utf-8')
         content = "movies" if content == 'movie' else "shows"
-        post = {
-            content: [{
-                "ids": {
-                    "trakt": trakt
-                }
-            }]
-        }
+        post = {content: [{"ids": {"trakt": trakt}}]}
 
         items = []
         if sctop.getSettingAsBool('trakt.collections'):
-            items = [(sctop.getString(30934).encode('utf-8'), '/sync/collection')]
+            items = [(sctop.getString(30934).encode('utf-8'),
+                      '/sync/collection')]
             items += [(sctop.getString(30935).encode('utf-8'),
                        '/sync/collection/remove')]
         if sctop.getSettingAsBool('trakt.watchlist'):
-            items += [(sctop.getString(30936).encode('utf-8'), '/sync/watchlist')]
+            items += [(sctop.getString(30936).encode('utf-8'),
+                       '/sync/watchlist')]
             items += [(sctop.getString(30937).encode('utf-8'),
                        '/sync/watchlist/remove')]
         items += [(sctop.getString(30989), 'rating')]
         items += [(sctop.getString(30938).encode('utf-8'),
                    '/users/me/lists/%s/items')]
-
 
         result = getTrakt('/users/me/lists')
         result = json.loads(result)
@@ -498,7 +496,8 @@ def manager(name, trakt, content):
         if select == -1:
             return
         elif items[select][1] == 'rating':
-            ratings = [(sctop.getString(i+30990).encode('utf-8'), i) for i in range(10,-1, -1)]
+            ratings = [(sctop.getString(i + 30990).encode('utf-8'), i)
+                       for i in range(10, -1, -1)]
             select = sctop.selectDialog([i[0] for i in ratings], str(name))
             url = "/sync/ratings/remove"
             if select == -1:
@@ -518,7 +517,8 @@ def manager(name, trakt, content):
 
             if 'added' in result:
                 if result['added'][content]:
-                    message = sctop.getString(30987).encode('utf-8') % ratings[select][1]
+                    message = sctop.getString(30987).encode(
+                        'utf-8') % ratings[select][1]
                 else:
                     return
 
@@ -554,11 +554,7 @@ def manager(name, trakt, content):
 
         icon = icon if not result == None else 'ERROR'
 
-        sctop.infoDialog(
-            message,
-            heading=str(name),
-            sound=True,
-            icon=icon)
+        sctop.infoDialog(message, heading=str(name), sound=True, icon=icon)
     except Exception as e:
         util.debug("[SC] trakt error: %s" % str(traceback.format_exc()))
         return

--- a/resources/lib/trakt.py
+++ b/resources/lib/trakt.py
@@ -454,19 +454,19 @@ def getSpecialLists(slug, page=1):
     return items
 
 
-def manager(name, imdb, tvdb, content):
+def manager(name, trakt, content):
     try:
         icon = sctop.infoLabel('ListItem.Icon')
         post = {
             "movies": [{
                 "ids": {
-                    "imdb": imdb
+                    "trakt": trakt
                 }
             }]
         } if content == 'movie' else {
             "shows": [{
                 "ids": {
-                    "tvdb": tvdb
+                    "trakt": trakt
                 }
             }]
         }

--- a/resources/lib/trakt.py
+++ b/resources/lib/trakt.py
@@ -233,27 +233,31 @@ def addTraktCollection(info):
 
 def getLists(user='me'):
     result = getTrakt('/users/%s/lists' % user)
+
     if not result:
         return []
     result = json.loads(result)
 
-    items = [
-        {
-            'type': 'dir',
-            'title': '[B]$30944[/B]',
-            #'url': 'cmd://Container.Update("%s")' % \
-            'action': 'traktShowList',
-            'id': 'watchlist',
-            'tl': 'watchlist',
-            'tu': user
-        },
-        {
-            'type': 'dir',
-            'title': '[B]$30958[/B]',
-            'action': 'traktHistory',
-            'id': 'history',
-            'tu': user
-        }
+    items = []
+    items_below = []
+    if sctop.getSettingAsBool('trakt.watchlist') or user != 'me':
+        items += [
+            {
+                'type': 'dir',
+                'title': '[B]$30944[/B]',
+                'action': 'traktShowList',
+                'id': 'watchlist',
+                'tl': 'watchlist',
+                'tu': user
+            }]
+
+    items += [{
+                'type': 'dir',
+                'title': '[B]$30958[/B]',
+                'action': 'traktHistory',
+                'id': 'history',
+                'tu': user
+        }]
         #,
         #{
         #    'type': 'dir',
@@ -261,36 +265,29 @@ def getLists(user='me'):
         #    'url': 'cmd://Container.Update("%s")' % \
         #        (xbmcutil._create_plugin_url({'action':'traktShowList', 'id':'progress'}))
         #}
-    ]
+
     if user == "me":
-        items += [
-            {
+        if sctop.getSettingAsBool('trakt.following'):
+            below = sctop.getSettingAsBool('trakt.following-below')
+            (items_below if below else items).append({
                 'action': 'traktFollowing',
                 'title': '[B]$30963[/B]',
                 'id': 'following',
                 'type': 'dir'
-            },
-            {
-                'action': 'traktSpecialLists',
-                'title': '[B]$30964[/B]',
-                'id': 'liked_lists',
-                'type': 'dir',
-            },
-            {
-                'action': 'traktSpecialLists',
-                'title': '[B]$30965[/B]',
-                'id': 'popular_lists',
-                'type': 'dir',
-                'page': '1'
-            },
-            {
-                'action': 'traktSpecialLists',
-                'title': '[B]$30966[/B]',
-                'id': 'trending_lists',
-                'type': 'dir',
-                'page': '1'
-            },
-        ]
+            })
+
+        for l, t in (('liked', '$30964'),
+                     ('popular', '$30965'),
+                     ('trending', '$30966')):
+            if sctop.getSettingAsBool('trakt.%s' % l):
+                (items_below if sctop.getSettingAsBool('trakt.%s-below' % l) else items).append({
+                    'action': 'traktSpecialLists',
+                    'title': '[B]%s[/B]' % t,
+                    'id': '%s_lists' % l,
+                    'type': 'dir',
+                    'page': '1'
+                })
+
     lists = [{
         'action': 'traktShowList',
         'title': i['name'],
@@ -300,9 +297,10 @@ def getLists(user='me'):
         'tu': user,
         'list': 'user'
     } for i in result]
+
     items += lists
 
-    return items
+    return items + items_below
 
 
 def getFollowing():
@@ -467,13 +465,16 @@ def manager(name, trakt, content):
             }]
         }
 
-        items = [(sctop.getString(30934).encode('utf-8'), '/sync/collection')]
-        items += [(sctop.getString(30935).encode('utf-8'),
-                   '/sync/collection/remove')]
-        items += [(sctop.getString(30936).encode('utf-8'), '/sync/watchlist')]
-        items += [(sctop.getString(30937).encode('utf-8'),
-                   '/sync/watchlist/remove')]
-        items += [(sctop.getString(30989), None)]
+        items = []
+        if sctop.getSettingAsBool('trakt.collections'):
+            items = [(sctop.getString(30934).encode('utf-8'), '/sync/collection')]
+            items += [(sctop.getString(30935).encode('utf-8'),
+                       '/sync/collection/remove')]
+        if sctop.getSettingAsBool('trakt.watchlist'):
+            items += [(sctop.getString(30936).encode('utf-8'), '/sync/watchlist')]
+            items += [(sctop.getString(30937).encode('utf-8'),
+                       '/sync/watchlist/remove')]
+        items += [(sctop.getString(30989), 'rating')]
         items += [(sctop.getString(30938).encode('utf-8'),
                    '/users/me/lists/%s/items')]
 
@@ -496,7 +497,7 @@ def manager(name, trakt, content):
 
         if select == -1:
             return
-        elif select == 4:
+        elif items[select][1] == 'rating':
             ratings = [(sctop.getString(i+30990).encode('utf-8'), i) for i in range(10,-1, -1)]
             select = sctop.selectDialog([i[0] for i in ratings], str(name))
             url = "/sync/ratings/remove"
@@ -527,7 +528,7 @@ def manager(name, trakt, content):
                 else:
                     return
 
-        elif select == 5:
+        elif items[select][1] == '/users/me/lists/%s/items':
             t = sctop.getString(30938).encode('utf-8')
             k = sctop.keyboard('', t)
             k.doModal()

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -86,4 +86,20 @@
         <setting type="sep" />
         <setting type="action" label="30405" option="close" action="RunPlugin(plugin://plugin.video.stream-cinema/?action=73756273)" />
     </category>
+    <category label="30080">
+        <setting label="30800" id="trakt.collections" type="bool" default="true" />
+        <setting label="30801" id="trakt.watchlist" type="bool" default="true" />
+        <setting type="sep"/>
+        <setting label="30802" id="trakt.following" type="bool" default="true" />
+        <setting label="30803" id="trakt.following-below" type="bool" default="false" visible="eq(-1,true)"/>
+        <setting type="sep"/>
+        <setting label="30804" id="trakt.liked" type="bool" default="true" />
+        <setting label="30805" id="trakt.liked-below" type="bool" default="false" visible="eq(-1,true)"/>
+        <setting type="sep"/>
+        <setting label="30806" id="trakt.popular" type="bool" default="true" />
+        <setting label="30807" id="trakt.popular-below" type="bool" default="false" visible="eq(-1,true)"/>
+        <setting type="sep"/>
+        <setting label="30808" id="trakt.trending" type="bool" defult="true"/>
+        <setting label="30809" id="trakt.trending-below" type="bool" default="false" visible="eq(-1,true)"/>
+    </category>
 </settings>


### PR DESCRIPTION
Pridal som do trakt managera rating. Trakt manager uziva trakt_id (doteraz uzival imdb a tvdb).

Dalej som pridal settings pre trakt.tv
pouzivat kolekcie (kedze nie su nikde vytiahnute, tak som pridal option, aby sa dalo vypnut "pridat do zbierky" z trak manageru)
+ pouzivat zoznam na pozretie - tiez mozno pre niekoho zbytocne
+ vsetky pokrocile zoznamy na vypnutie a na umiestnenie (predsa len ja preferujem, ked mam co najvyssie moje zoznamy a ostatne polozky ako trending list, popular list su dole).

Este rozmyslam, ci nedorobit do notifikacneho okna trakt manageru notifikacny message, co sa vlastne stalo, pripadne tam zobrazit zvolenu akciu z pola items[select][0], lebo ked je tam strohy message "Trakt Manager/Spravca Traktu", tak nie je jasne, aka akcia sa vykonala (uz som sa par krat uklepol a miesto pridat do zoznamu som dal odobrat zo zoznamu a pritom ten film v tom zozname uz bol...). 