### PR TITLE
Relevantne polozky v trakt manazeri

### DIFF
--- a/resources/language/Czech/strings.xml
+++ b/resources/language/Czech/strings.xml
@@ -89,6 +89,7 @@
     <string id="30807">Populární playlisty pod mými seznamy</string>
     <string id="30808">Zobrazit populární seznamy za týden</string>
     <string id="30809">Populární playlisty za týden pod mými seznamy</string>
+    <string id="30810">Zobraziť len relevantné akcie v Správcovi Traktu</string>
 
     <!-- texty v menu -->
     <string id="30901">Filmy</string>
@@ -129,6 +130,8 @@
     <string id="30938">Přidat do [B]nového seznamu[/B]</string>
     <string id="30939">Přidat do [B]%s[/B]</string>
     <string id="30940">Odebrat ze [B]%s[/B]</string>
+    <string id="30811">Vyčistit paměť Správce Traktu</string>
+    <string id="30812">Paměť vyčištena</string>
     
     <string id="30941">Správce Traktu</string>
     

--- a/resources/language/English/strings.xml
+++ b/resources/language/English/strings.xml
@@ -89,6 +89,7 @@
     <string id="30807">Popular Lists below your lists</string>
     <string id="30808">Display Trending Lists</string>
     <string id="30809">Trending Lists below your lists</string>
+    <string id="30810">Show only relevant actions in Trakt Manager</string>
     
     <!-- texty v menu -->
     <string id="30901">Movies</string>
@@ -129,6 +130,8 @@
     <string id="30938">Add to [B]new List[/B]</string>
     <string id="30939">Add to [B]%s[/B]</string>
     <string id="30940">Remove from [B]%s[/B]</string>
+    <string id="30811">Clear Trakt Manager's cache</string>
+    <string id="30812">Cache cleared</string>
     
     <string id="30941">Trakt Manager</string>
     

--- a/resources/language/Slovak/strings.xml
+++ b/resources/language/Slovak/strings.xml
@@ -89,6 +89,7 @@
     <string id="30807">Populárne zoznamy pod mojimi zoznamami</string>
     <string id="30808">Zobraziť populárne zoznamy za týždeň</string>
     <string id="30809">Populárne zoznamy za týždeň pod mojimi zoznamami</string>
+    <string id="30810">Zobraziť len relevantné akcie v Správcovi Traktu</string>
 
     <!-- texty v menu -->
     <string id="30901">Filmy</string>
@@ -129,6 +130,8 @@
     <string id="30938">Pridať do [B]nového zoznamu[/B]</string>
     <string id="30939">Pridať do [B]%s[/B]</string>
     <string id="30940">Odobrať z [B]%s[/B]</string>
+    <string id="30811">Vyčistiť pamäť Správcu Traktu</string>
+    <string id="30812">Pamäť vyčistená</string>
     
     <string id="30941">Správca Traktu</string>
     

--- a/resources/lib/trakt.py
+++ b/resources/lib/trakt.py
@@ -503,20 +503,26 @@ def manager(name, trakt, content):
         for lst in lists:
             key = 'trakt.lists.%s.%s.ids' % (lst['ids']['trakt'], content)
             if relevant:
-                ids = _get_cached_ids(key, '/users/me/lists/%s/items/%s' % (lst['ids']['slug'], content))
+                ids = _get_cached_ids(
+                    key, '/users/me/lists/%s/items/%s' % (lst['ids']['slug'],
+                                                          content))
             if not relevant or trakt not in ids:
-                items.append(((sctop.getString(30939) % lst['name']).encode('utf-8'),
-                        '/users/me/lists/%s/items' % lst['ids']['slug'], key))
+                items.append(
+                    ((sctop.getString(30939) % lst['name']).encode('utf-8'),
+                     '/users/me/lists/%s/items' % lst['ids']['slug'], key))
 
             if not relevant or trakt in ids:
-                items.append(((sctop.getString(30940) % lst['name']).encode('utf-8'),
-                        '/users/me/lists/%s/items/remove' % lst['ids']['slug'], key))
+                items.append(
+                    ((sctop.getString(30940) % lst['name']).encode('utf-8'),
+                     '/users/me/lists/%s/items/remove' % lst['ids']['slug'],
+                     key))
 
         items += [(sctop.getString(30938).encode('utf-8'),
                    '/users/me/lists/%s/items')]
 
         if relevant:
-            items.append((sctop.getString(30811).encode('utf-8'), 'clear_cache'))
+            items.append((sctop.getString(30811).encode('utf-8'),
+                          'clear_cache'))
 
         select = sctop.selectDialog([i[0] for i in items],
                                     sctop.getString(30941).encode('utf-8'))
@@ -588,14 +594,14 @@ def manager(name, trakt, content):
                     sctop.cache.set(key, None, expiration=ttl)
 
             result = getTrakt('/users/me/lists')
-            lists  = json.loads(result)
+            lists = json.loads(result)
             for l in lists:
                 for c in contents:
                     key = 'trakt.lists.%s.%s.ids' % (l['ids']['trakt'], c)
                     sctop.cache.set(key, None, expiration=ttl)
 
             message = sctop.getString(30812).encode('utf-8')
-            name    = sctop.getString(30941).encode('utf-8')
+            name = sctop.getString(30941).encode('utf-8')
         else:
             result = getTrakt(items[select][1], post=post)
             key = items[select][2]
@@ -603,7 +609,7 @@ def manager(name, trakt, content):
                 ids = sctop.cache.get(key)
                 if type(ids) is list:
                     if items[select][1][-7:] == '/remove':
-                        ids = [ i for i in ids if i != trakt ]
+                        ids = [i for i in ids if i != trakt]
                     else:
                         ids.append(trakt)
                     sctop.cache.set(key, ids)
@@ -626,12 +632,17 @@ def listAppendToCustom(user, list_id):
     dst_list = lists[select]
     dst_items = _getListItemsForImport(user, list_id)
     result, code, info = getTrakt(
-        '/users/me/lists/%s/items' % dst_list[0], post=dst_items, output="info")
+        '/users/me/lists/%s/items' % dst_list[0],
+        post=dst_items,
+        output="info")
     if code == 201:
         sctop.infoDialog("%s" % dst_list[1],
                          sctop.getString(30969).encode("utf-8"))
         for c in ['shows', 'movies']:
-            sctop.cache.set('trakt.lists.%s.%s' % (dst_list[2], c), None, expiration=timedelta())
+            sctop.cache.set(
+                'trakt.lists.%s.%s' % (dst_list[2], c),
+                None,
+                expiration=timedelta())
     else:
         util.debug(
             '[SC] import to %s failed. %d, %s' % (dst_list[0], code, result))
@@ -915,6 +926,7 @@ def _getListItemsForImport(user, list_id):
         })
     return result
 
+
 def _get_cached_ids(key, url):
     ids = sctop.cache.get(key)
     if type(ids) is not list:
@@ -922,6 +934,7 @@ def _get_cached_ids(key, url):
         ids = [i[i['type']]['ids']['trakt'] for i in json.loads(result)]
         sctop.cache.set(key, ids)
     return ids
+
 
 def _getUserName(user):
     return user['name'] if user['name'] else user['username']

--- a/resources/settings.xml
+++ b/resources/settings.xml
@@ -103,5 +103,7 @@
         <setting type="sep"/>
         <setting label="30808" id="trakt.trending" type="bool" defult="true"/>
         <setting label="30809" id="trakt.trending-below" type="bool" default="false" visible="eq(-1,true)"/>
+        <setting type="sep"/>
+        <setting label="30810" id="trakt.relevant_menu" type="bool" default="false" />
     </category>
 </settings>


### PR DESCRIPTION
Dorobil som kontrolu filmu/serialu v trakt manazeri na pritomnost v zozname, tak aby sa v menu zobrazovali len relevantne polozky (Pridat do zoznamu, ked tam nie je, zmazat zo zoznamu, ak tam je...)
Kedze sa trakt zoznamy daju manazovat aj z webu a nemusi byt vzdy in-sync, je tam pridana moznost zmazat cache.
Tak isto som dalsie akcie, ktore suvisia so zoznamami (clone, import, delete) doplnil o mazanie cache a "Pridat do noveho zoznamu" presunul na koniec, kedze nove zoznamy sa nevytvaraju na dennom poriadku.