### PR TITLE
Fix ElementTree import that stopped working after the latest Kodi update

### DIFF
--- a/resources/lib/myprovider/webshare.py
+++ b/resources/lib/myprovider/webshare.py
@@ -19,7 +19,7 @@
 # */
 from crypto.md5crypt import md5crypt
 from datetime import timedelta
-import elementtree.ElementTree as ET
+import xml.etree.ElementTree as ET
 import hashlib
 from provider import ResolveException
 import traceback


### PR DESCRIPTION
I don't know Python much so I don't know the exact reason but after the latest Kodi update the video playback stopped working for me so I digged into the logs and found an error that lead me to bad import. So I tried to change it and it fixed it for me so I guess we should merge it to master.